### PR TITLE
fix frontend loading state

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -1,4 +1,6 @@
 /** @type {import('next').NextConfig} */
+const basePath = process.env.NEXT_PUBLIC_BASE_PATH || '';
+
 const nextConfig = {
   reactStrictMode: true,
   swcMinify: true,
@@ -9,8 +11,11 @@ const nextConfig = {
   // Only enable static export for production builds, not development
   ...(process.env.NODE_ENV === 'production' && {
     output: 'export', // Enable static export for GitHub Pages
-    // Removed assetPrefix and basePath to fix GitHub Pages routing
-    // GitHub Pages will handle the subdirectory automatically
+    // When hosting from a subdirectory (such as GitHub Pages) Next.js needs to
+    // know the mount point so it can generate correct links to scripts and
+    // assets. The assetPrefix mirrors the basePath with a trailing slash.
+    basePath,
+    assetPrefix: `${basePath}/`,
     // Force cache busting for JavaScript chunks
     generateBuildId: () => Date.now().toString()
   }),
@@ -41,6 +46,9 @@ const nextConfig = {
   // Environment variables for configuration
   env: {
     CUSTOM_KEY: 'my-value',
+    // Expose the base path to client-side code so fetches can build URLs that
+    // work both locally and in production.
+    NEXT_PUBLIC_BASE_PATH: basePath,
   },
 };
 

--- a/services/graphDataService.ts
+++ b/services/graphDataService.ts
@@ -13,10 +13,12 @@ import { GraphData } from '../types/conceptGraph';
  * @returns A Promise resolving to the strongly typed GraphData object.
  */
 export async function fetchGraphData(
-  url = '/data/concept-graph-data.json'
+  url = `${process.env.NEXT_PUBLIC_BASE_PATH || ''}/data/concept-graph-data.json`
 ): Promise<GraphData> {
-  // Perform the HTTP request using the browser's Fetch API.  In a Next.js client
-  // component this API is globally available.
+  // The default URL pulls in an optional NEXT_PUBLIC_BASE_PATH environment
+  // variable. Static sites often live inside a subdirectory, so this approach
+  // lets the same code fetch the dataset whether the app is served from the
+  // domain root or from a nested folder.
   const response = await fetch(url);
 
   // Guard clause: immediately report network failures to the caller.


### PR DESCRIPTION
## Summary
- ensure Next.js builds include base and asset prefixes so scripts load on GitHub Pages
- fetch graph data using optional base path so dataset loads when hosted in a subdirectory

## Testing
- `npm test` *(fails: Cannot find module '../../src/domain/entities/Paper')*

------
https://chatgpt.com/codex/tasks/task_e_68a00dcaa97c83238e0af1da1586d2ea