### PR TITLE
fix: restore asset prefix for gh pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,20 @@ The `fetchGraphData` service loads this file using an absolute path (`/data/...`
 so the application functions correctly whether served from the domain root or a
 sub‑path such as GitHub Pages.
 
+### Deployment
+When hosting the exported site on GitHub Pages the files live under a URL that
+includes the repository name (for example
+`https://<user>.github.io/academic-paper-discovery/`).
+
+The `next.config.js` file contains a small snippet that sets both `assetPrefix`
+and `basePath` to this repository name during production builds.  These options
+instruct Next.js to prefix every JavaScript, CSS and image request with the
+sub‑directory so the browser can locate them.  If you fork this project, update
+the `repoName` constant near the top of that configuration file to match your
+new repository.  Skipping this step typically results in 404 errors for files
+like `index-*.js`, `_buildManifest.js` and `_ssgManifest.js` when viewing the
+deployed site.
+
 ## Testing
 ```bash
 # JavaScript/TypeScript tests

--- a/next.config.js
+++ b/next.config.js
@@ -1,28 +1,58 @@
+/**
+ * Next.js configuration used by both development and production builds.
+ *
+ * The configuration is intentionally verbose to teach how each option affects
+ * deployment.  Variables declared above the exported object keep related
+ * values grouped and make the conditional logic easier to read.
+ */
+
+// GitHub Pages serves the site from a subdirectory named after the repository.
+// In production we prefix all asset URLs with this directory so that
+// `https://<user>.github.io/academic-paper-discovery/` can locate the static
+// files.  During local development we keep paths root‑relative for simplicity.
+const repoName = 'academic-paper-discovery';
+const isProd = process.env.NODE_ENV === 'production';
+
 /** @type {import('next').NextConfig} */
 const nextConfig = {
+  // Enforces additional React runtime checks which highlight common mistakes.
   reactStrictMode: true,
+  // Uses the faster SWC compiler for minification rather than terser.
   swcMinify: true,
+  // Ensures every route ends with a trailing slash, matching GitHub Pages
+  // behaviour and avoiding duplicate content issues.
   trailingSlash: true,
   images: {
-    unoptimized: true, // Required for static export to GitHub Pages
+    // GitHub Pages is a static host and cannot run Next.js' dynamic image
+    // optimisation pipeline, so images are served as‑is.
+    unoptimized: true,
   },
-  // Only enable static export for production builds, not development
-  ...(process.env.NODE_ENV === 'production' && {
-    output: 'export', // Enable static export for GitHub Pages
-    // Removed assetPrefix and basePath to fix GitHub Pages routing
-    // GitHub Pages will handle the subdirectory automatically
-    // Force cache busting for JavaScript chunks
-    generateBuildId: () => Date.now().toString()
+  // Only enable static export and path rewriting for production builds.  This
+  // block is omitted in development where a Node server provides assets
+  // directly.
+  ...(isProd && {
+    // Produce plain HTML/JS/CSS that can be hosted without a Node server.
+    output: 'export',
+    // Prefix all built assets with the repository name so that requests such as
+    // `/_next/static/...` resolve correctly when the site is served from
+    // `/academic-paper-discovery` instead of the domain root.  Without this the
+    // browser would request files from the wrong location and show 404 errors
+    // like the ones in the problem statement.
+    assetPrefix: `/${repoName}/`,
+    basePath: `/${repoName}`,
+    // Simple cache‑busting strategy: change build ID each deployment so browsers
+    // fetch the latest JavaScript bundles.
+    generateBuildId: () => Date.now().toString(),
   }),
   
   // Set custom pages directory for Clean Architecture organization
   pageExtensions: ['tsx', 'ts'],
   
-  // Educational Note: Configuration optimized for GitHub Pages deployment
-  // - Static export eliminates need for Node.js server
-  // - Asset prefix handles GitHub Pages subdirectory routing
-  // - Image optimization disabled for static hosting compatibility
-  // - Trailing slash ensures consistent routing behavior
+  // Educational Note: Configuration optimised for GitHub Pages deployment
+  // - Static export eliminates need for a Node.js server.
+  // - `assetPrefix` and `basePath` route requests to the correct subdirectory.
+  // - Image optimisation is disabled to suit static hosting.
+  // - Trailing slashes keep navigation consistent across environments.
   
   // Webpack configuration for Clean Architecture path aliases
   webpack: (config) => {


### PR DESCRIPTION
## Summary
- ensure next.js generates correct URLs for GitHub Pages by setting assetPrefix and basePath
- document GitHub Pages deployment steps and repoName config

## Testing
- `npm test` (fails: Cannot find module '../../src/application/use_cases/ExtractConceptsUseCase')
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a00e2d85b48323bd1792f8a68df68f